### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ categories = ["compression"]
 "default" = ["bzip2", "deflate"]
 
 [dependencies]
-log = "0.4.8"
-zip = "0.5.6"
+log = "0.4.14"
+zip = "0.5.13"
 thiserror = "1.0"
 
 [dev-dependencies]
-cute-log = { version = "1.4.1", default_features = false }
+cute-log = { version = "2.0.7", default_features = false }
 dir-diff = "0.3.2"
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub fn extract<S: Read + Seek>(
     debug!("Extracting to {}", target_dir.to_string_lossy());
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
-        let mut relative_path = file.sanitized_name();
+        let mut relative_path = file.mangled_name();
 
         if do_strip_toplevel {
             let base = relative_path
@@ -152,7 +152,7 @@ fn has_toplevel<S: Read + Seek>(
     }
 
     for i in 0..archive.len() {
-        let file = archive.by_index(i)?.sanitized_name();
+        let file = archive.by_index(i)?.mangled_name();
         if let Some(toplevel_dir) = &toplevel_dir {
             if !file.starts_with(toplevel_dir) {
                 trace!("Found different toplevel directory");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ extern crate log;
 use std::os::unix::fs::PermissionsExt;
 
 use std::io::{Read, Seek};
-use std::path::{PathBuf, StripPrefixError};
+use std::path::{Path, PathBuf, StripPrefixError};
 use std::{fs, io};
 use thiserror::Error;
 
@@ -76,7 +76,7 @@ pub enum ZipExtractError {
 /// If on unix, `extract` will preserve permissions while extracting.
 pub fn extract<S: Read + Seek>(
     source: S,
-    target_dir: &PathBuf,
+    target_dir: &Path,
     strip_toplevel: bool,
 ) -> Result<(), ZipExtractError> {
     if !target_dir.exists() {
@@ -115,7 +115,7 @@ pub fn extract<S: Read + Seek>(
             continue;
         }
 
-        let mut outpath = target_dir.clone();
+        let mut outpath = target_dir.to_path_buf();
         outpath.push(relative_path);
 
         trace!(
@@ -173,7 +173,7 @@ fn has_toplevel<S: Read + Seek>(
 }
 
 #[cfg(unix)]
-fn set_unix_mode(file: &zip::read::ZipFile, outpath: &PathBuf) -> io::Result<()> {
+fn set_unix_mode(file: &zip::read::ZipFile, outpath: &Path) -> io::Result<()> {
     if let Some(m) = file.unix_mode() {
         fs::set_permissions(&outpath, PermissionsExt::from_mode(m))?
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,5 @@
+use cute_log::log::LevelFilter;
+use cute_log::Logger;
 use dir_diff;
 use std::io::Cursor;
 use std::path::PathBuf;
@@ -10,7 +12,11 @@ use zip_extract::{extract, ZipExtractError};
 static INIT: Once = Once::new();
 
 fn initialize() {
-    INIT.call_once(|| cute_log::debug_init().unwrap());
+    INIT.call_once(|| {
+        const LOGGER: Logger = Logger::new();
+        LOGGER.set_max_level(LevelFilter::Debug);
+        LOGGER.set_logger().unwrap();
+    });
 }
 
 #[test]


### PR DESCRIPTION
Hi!

I updated the dependencies and applied clippy suggestions in this PR. Also, there was a couple of changes due to the new version of `zip` so I fixed those deprecation warnings as well. (See [`sanitized_name`](https://docs.rs/zip/latest/zip/read/struct.ZipFile.html#method.sanitized_name))

Thanks for this nice library! :bear:
