### PR TITLE
Swap out unmaintained `tempdir` for `tempfile` as per `cargo audit` warning suggestion.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "1.0"
 [dev-dependencies]
 cute-log = { version = "2.0.7", default_features = false }
 dir-diff = "0.3.2"
-tempdir = "0.3.7"
+tempfile = "3.4.0"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,6 @@ use dir_diff;
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Once;
-use tempdir::TempDir;
 use zip::result::ZipError::InvalidArchive;
 use zip_extract::ZipExtractError::Zip;
 use zip_extract::{extract, ZipExtractError};
@@ -25,7 +24,7 @@ fn valid_archive() {
 
     let mut source = vec![];
     source.extend_from_slice(include_bytes!("data/valid.zip"));
-    let mut target = TempDir::new("zip-extract").unwrap().into_path();
+    let mut target = get_tempdir();
     target.push("test"); // let zip-extract create it
 
     extract(Cursor::new(source), &target, true).unwrap();
@@ -38,7 +37,7 @@ fn valid_archive_with_toplevel() {
 
     let mut source = vec![];
     source.extend_from_slice(include_bytes!("data/valid_toplevel.zip"));
-    let mut target = TempDir::new("zip-extract").unwrap().into_path();
+    let mut target = get_tempdir();
     target.push("test"); // let zip-extract create it
 
     extract(Cursor::new(source), &target, true).unwrap();
@@ -52,7 +51,7 @@ fn valid_archive_forbid_toplevel() {
 
     let mut source = vec![];
     source.extend_from_slice(include_bytes!("data/valid_toplevel.zip"));
-    let mut target = TempDir::new("zip-extract").unwrap().into_path();
+    let mut target = get_tempdir();
     target.push("test"); // let zip-extract create it
 
     extract(Cursor::new(source), &target, false).unwrap();
@@ -85,4 +84,13 @@ fn invalid_archive() {
     } else {
         false
     });
+}
+
+fn get_tempdir() -> PathBuf {
+    tempfile::Builder::new()
+        .prefix("zip-extract.")
+        .rand_bytes(12)
+        .tempdir()
+        .unwrap()
+        .into_path()
 }


### PR DESCRIPTION
This PR follows the advice of `cargo audit` documented in https://github.com/MCOfficer/zip-extract/issues/11 to replace the unmaintained `tempdir` dev-dependency with `tempfile`.

I believe the semantics of the replacement are identical.

On my system on this branch `cargo audit` reports no errors or warnings and `cargo test` succeeds. The generated temp directories have the same name schema as prior to this patch.