### PR TITLE
fix: mirror the features of the zip crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,22 @@ repository = "https://github.com/MCOfficer/zip-extract"
 keywords = ["zip", "archive", "extract"]
 categories = ["compression"]
 
+# Mirrors the features of zip package
+# https://github.com/zip-rs/zip/blob/master/Cargo.toml#L36
 [features]
-"deflate" = ["zip/deflate"]
-"deflate-miniz" = ["zip/deflate-miniz"]
-"default-zlib" = ["zip/deflate-zlib"]
-"bzip2" = ["zip/bzip2"]
-"default" = ["bzip2", "deflate"]
+aes-crypto = ["zip/aes-crypto"]
+deflate = ["zip/deflate"]
+deflate-miniz = ["zip/deflate-miniz"]
+deflate-zlib = ["zip/deflate-zlib"]
+unreserved = ["zip/unreserved"]
+bzip2 = ["zip/bzip2"]
+time = ["zip/time"]
+zstd = ["zip/zstd"]
+default = ["aes-crypto", "bzip2", "deflate", "time", "zstd"]
 
 [dependencies]
 log = "0.4.14"
-zip = "0.6.4"
+zip = { version = "0.6.4", default_features = false }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ unreserved = ["zip/unreserved"]
 bzip2 = ["zip/bzip2"]
 time = ["zip/time"]
 zstd = ["zip/zstd"]
-default = ["aes-crypto", "bzip2", "deflate", "time", "zstd"]
+default = ["aes-crypto", "bzip2", "deflate", "zstd"]
 
 [dependencies]
 log = "0.4.14"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ zip_extract::extract(Cursor::new(archive), &target_dir, true)?;
 
 ## Features
 
-All features are the same as the features of the `zip` crate:
+All features are the same as the features of the [`zip`](https://github.com/zip-rs/zip/tree/v0.6.4#usage) crate:
 
 - `aes-crypto`: Support for AES encryption via the the `zip` crate
 - `deflate`: Support for the Deflate algorithm (`miniz_oxide` rust-backend)

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ All features are the same as the features of the [`zip`](https://github.com/zip-
 - `bzip2`: Support for .bzip2 archives via the `bzip2` crate
 - `time`: Support for the `time` crate for the `zip` crate
 - `zstd`: Support for the `zstd` crate for the `zip` crate
-- `default`: enables `"aes-crypto", "bzip2", "deflate", "time", "zstd"`
+- `default`: enables `"aes-crypto", "bzip2", "deflate", "zstd"`

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ zip_extract::extract(Cursor::new(archive), &target_dir, true)?;
 
 
 ## Features
-All features are passed through to `zip` and `flate2`. They are:
 
+All features are the same as the features of the `zip` crate:
+
+- `aes-crypto`: Support for AES encryption via the the `zip` crate
 - `deflate`: Support for the Deflate algorithm (`miniz_oxide` rust-backend)
 - `deflate-miniz`: ^ dito (`miniz` C-backend)
 - `deflate-zlib`: ^ dito (`zlib` C-backend)
+- `unreserved`: Support for the `unreserved` feature of the `zip` crate
 - `bzip2`: Support for .bzip2 archives via the `bzip2` crate
-
-The default is `bzip2` and `deflate`.
+- `time`: Support for the `time` crate for the `zip` crate
+- `zstd`: Support for the `zstd` crate for the `zip` crate
+- `default`: enables `"aes-crypto", "bzip2", "deflate", "time", "zstd"`


### PR DESCRIPTION
This mirrors the features of the zip crate so that we can use things like `default_features = false` to disable zstd for example.